### PR TITLE
Fix for issue https://wso2.org/jira/browse/MB-890

### DIFF
--- a/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distrupter/ConcurrentBatchProcessor.java
+++ b/modules/andes-core/broker/src/main/java/org/wso2/andes/kernel/distrupter/ConcurrentBatchProcessor.java
@@ -154,10 +154,8 @@ public class ConcurrentBatchProcessor implements EventProcessor {
                                     + eventType);
                         }
                         eventList.clear();
-
                     }
                     nextSequence++;
-
                 }
 
                 sequence.set(nextSequence - 1L);
@@ -169,6 +167,10 @@ public class ConcurrentBatchProcessor implements EventProcessor {
                 log.error("Exception occurred while processing batch for type " + eventType, ex);
                 exceptionHandler.handleEventException(ex, nextSequence, event);
                 sequence.set(nextSequence);
+
+                // Dropping events with errors from batch processor. Relevant event handler should take care of
+                // the events. If not cleared next iteration would contain the previous iterations event list
+                eventList.clear();
                 nextSequence++;
             }
         }


### PR DESCRIPTION
When an exception occur on ConcurrentBatchProcessor while calling
onEvent(...) of relevant even handler exception is handle without
clearing the current batched event list. Therefore after handling
the exception, in the next iteration batch processor feeds the
event handler with a list with new events including the events from
erronous previous iteration.
This leads to feeding events to handler that are already cleared.

Fixed this by clearing the eventlist when an exception is caught.